### PR TITLE
Fix minor issues:

### DIFF
--- a/abstract/fragment.h
+++ b/abstract/fragment.h
@@ -31,7 +31,8 @@
  */
 
 #ifdef __cplusplus
-namespace ufmt::EVB {
+namespace ufmt{
+  namespace EVB {
 #endif
   /*
    *  Below are valid barrier types.
@@ -97,7 +98,7 @@ namespace ufmt::EVB {
   } FlatFragment, *pFlatFragment;
 
 #ifdef __cplusplus
-}
+  }}
 #endif
   /**
    * Below are convenience functions for fragments:

--- a/v12/CRingItem.cpp
+++ b/v12/CRingItem.cpp
@@ -318,6 +318,9 @@ namespace ufmt {
     int                 nPerLine(8);
 
     dump << bodyHeaderToString();
+
+    auto result = dump.str();
+    return result;
   
   }
 


### PR DESCRIPTION
1.  fragment.h - should do: namespace ufmt {
  namespace EVB
 rather than namespace ufmt::EVB

  compilers prior to std17.
2. fix warning about ufmt::v12::CRingItem::headerToString - forgot the malarky to actually generate a return value.