### PR TITLE
Ensure all TITLE_MAXSIZE are acutally uint32_t so that

### DIFF
--- a/v11/DataFormat.h
+++ b/v11/DataFormat.h
@@ -157,11 +157,7 @@ namespace ufmt {
 
   /* Longest allowed title: */
 
-  #ifndef TITLE_MAXSIZE
-  #ifndef DATAFORMAT_H     // Abstract data format.h defines title as well.
-  #define TITLE_MAXSIZE 80
-  #endif
-  #endif
+    static const uint32_t TITLE_MAXSIZE(80);
 
 
   // Macro to make packed structs:

--- a/v12/DataFormat.h
+++ b/v12/DataFormat.h
@@ -167,9 +167,7 @@ namespace ufmt {
 
   /* Longest allowed title: */
 
-  //#ifndef TITLE_MAXSIZE
-  //#define TITLE_MAXSIZE 80
-  //#endif
+
   static const unsigned TITLE_MAXSIZE(80);
 
   /* Macro to make packed structs: */


### PR DESCRIPTION
there are not macro expansion conflicts.