### PR TITLE
Fix some namespacing issues with v12/DataFormat.h -it's includes

### DIFF
--- a/v12/CRingItem.cpp
+++ b/v12/CRingItem.cpp
@@ -20,13 +20,13 @@
 #include "CRingItem.h"
 #include "DataFormat.h"
 
-
 #include <string.h>
 #include <string>
 #include <sstream>
 #include <iomanip>
 #include <stdexcept>
 #include <unistd.h>
+
 
 namespace ufmt {
   namespace v12 {

--- a/v12/DataFormat.h
+++ b/v12/DataFormat.h
@@ -1,5 +1,7 @@
 #ifndef V12_DATAFORMAT_H
 #define V12_DATAFORMAT_H
+#include <stdint.h>
+#include <time.h>
 
 namespace ufmt {
   namespace v12 {
@@ -93,19 +95,7 @@ namespace ufmt {
   */
 
 
-  #ifndef __CRT_STDINT_H
-  #include <stdint.h>
-  #ifndef __CRT_STDINT_H
-  #define __CRT_STDINT_H
-  #endif
-  #endif
-
-  #ifndef __CRT_TIME_H
-  #include <time.h>
-  #ifndef __CRT_TIME_H
-  #define __CRT_TIME_H
-  #endif
-  #endif
+  
 
   /*
       11.0 and later define a format item that starts the run.


### PR DESCRIPTION
must be done outside the namespace for system headers.

This makes a good bookworm compile.