### PR TITLE
Rfoxkendo/issue17

### DIFF
--- a/v11/CRingStateChangeItem.h
+++ b/v11/CRingStateChangeItem.h
@@ -51,7 +51,7 @@ namespace ufmt {
             uint32_t runNumber,
             uint32_t timeOffset,
             time_t   timestamp,
-            std::string title) ;
+            std::string title, uint32_t offsetDivisor = 1) ;
     CRingStateChangeItem(uint64_t eventTimestamp, uint32_t sourceId, uint32_t barrierType,
                         uint16_t reason,
             uint32_t runNumber,
@@ -78,6 +78,7 @@ namespace ufmt {
 
     virtual void setElapsedTime(uint32_t offset);
     virtual uint32_t getElapsedTime() const;
+    virtual uint32_t getTimeDivisor() const;
     virtual float    computeElapsedTime() const;
 
     virtual void setTitle(std::string title) ;
@@ -107,8 +108,8 @@ namespace ufmt {
 
     // Utitlity functions..
 
-  private:
-    bool isStateChange();
+
+    static bool isStateChange(uint32_t type) ;
     
   };
   }

--- a/v11/v11factoryTests.cpp
+++ b/v11/v11factoryTests.cpp
@@ -36,7 +36,7 @@
 #include <CRingScalerItem.h>
 #include <CRingTextItem.h>
 #include <CUnknownFragment.h>
-#include <CRingStateChangeItem.h>
+#include "CRingStateChangeItem.h"    // V11
 
 #include <string.h>
 #ifdef HAVE_NSCLDAQ    
@@ -132,6 +132,7 @@ class v11facttest : public CppUnit::TestFixture {
     CPPUNIT_TEST(state_2);
     CPPUNIT_TEST(state_3);
     CPPUNIT_TEST(state_4);
+    CPPUNIT_TEST(state_5);   // issue #17 test.
     CPPUNIT_TEST_SUITE_END();
     
 private:
@@ -204,6 +205,7 @@ protected:
     void state_2();
     void state_3();
     void state_4();
+    void state_5();
 };
 
 CPPUNIT_TEST_SUITE_REGISTRATION(v11facttest);
@@ -1582,7 +1584,23 @@ void v11facttest::state_4()
     );
     CPPUNIT_ASSERT_THROW(
         m_pFactory->makeStateChangeItem(*pItem),
-        std::logic_error
+        std::bad_cast
     );
     
+}
+// state changes with non-unit divisor can be properly constructed.
+
+void v11facttest::state_5() {
+    time_t now = time(nullptr);
+    ::ufmt::v11::CRingStateChangeItem src(
+        1234, 2, 1, BEGIN_RUN,
+        1, 10, now, "This is a title", 2
+    );
+    
+    std::unique_ptr<::CRingStateChangeItem> pItem;
+    CPPUNIT_ASSERT_NO_THROW(
+        pItem.reset(m_pFactory->makeStateChangeItem(src))
+    );
+    EQ(uint32_t(2), pItem->getTimeDivisor());
+    EQ(float(5.0), pItem->computeElapsedTime());
 }

--- a/v11/v11factoryTests.cpp
+++ b/v11/v11factoryTests.cpp
@@ -1603,4 +1603,17 @@ void v11facttest::state_5() {
     );
     EQ(uint32_t(2), pItem->getTimeDivisor());
     EQ(float(5.0), pItem->computeElapsedTime());
+
+    // Now when the sourcde has a body header:
+
+    ufmt::v11::CRingStateChangeItem sbh(
+        0x124356789, 1, 1, BEGIN_RUN,
+        12, 10, now, "A title", 2
+    );
+    CPPUNIT_ASSERT_NO_THROW(
+        pItem.reset(m_pFactory->makeStateChangeItem(sbh))
+    );
+    CPPUNIT_ASSERT_NO_THROW(
+        pItem.reset(m_pFactory->makeStateChangeItem(src))
+    );
 }

--- a/v12/CRingStateChangeItem.cpp
+++ b/v12/CRingStateChangeItem.cpp
@@ -76,7 +76,7 @@ namespace ufmt {
               uint32_t runNumber,
               uint32_t timeOffset,
               time_t   timestamp,
-              std::string title) :
+              std::string title, uint32_t divisor) :
     ::ufmt::CRingStateChangeItem(reason)
 
   {
@@ -92,6 +92,9 @@ namespace ufmt {
     v12::pStateChangeItemBody pBody = &(pItem->s_body.u_noBodyHeader.s_body);
     fillStateChangeBody(pBody, runNumber, timeOffset, 1, timestamp, title.c_str(), 0);
     
+    // Patch in the divisor:
+
+    pBody->s_offsetDivisor = divisor;
     setBodyCursor(pBody+1);
     updateSize();
     

--- a/v12/CRingStateChangeItem.h
+++ b/v12/CRingStateChangeItem.h
@@ -48,7 +48,7 @@ namespace ufmt {
             uint32_t runNumber,
             uint32_t timeOffset,
             time_t   timestamp,
-            std::string title) ;
+            std::string title, uint32_t divisor=1) ;
     CRingStateChangeItem(uint64_t eventTimestamp, uint32_t sourceId, uint32_t barrierType,
                         uint16_t reason,
             uint32_t runNumber,

--- a/v12/RingItemFactory.cpp
+++ b/v12/RingItemFactory.cpp
@@ -811,13 +811,13 @@ namespace ufmt {
             return new v12::CRingStateChangeItem(
                 rhs.getEventTimestamp(), rhs.getSourceId(), rhs.getBarrierType(),
                 rhs.type(), pBody->s_runNumber, pBody->s_timeOffset,
-                pBody->s_Timestamp, pBody->s_title
+                pBody->s_Timestamp, pBody->s_title, pBody->s_offsetDivisor
             );
         } else {
             return new v12::CRingStateChangeItem(
                 rhs.type(), pBody->s_runNumber, pBody->s_timeOffset,
                 pBody->s_Timestamp,
-                pBody->s_title
+                pBody->s_title, pBody->s_offsetDivisor
             );
         }
         

--- a/v12/v12factorytests.cpp
+++ b/v12/v12factorytests.cpp
@@ -133,6 +133,7 @@ class v12facttest : public CppUnit::TestFixture {
     CPPUNIT_TEST(state_3);
     CPPUNIT_TEST(state_4);
     CPPUNIT_TEST(state_5);
+    CPPUNIT_TEST(state_6);
     CPPUNIT_TEST_SUITE_END();
     
 private:
@@ -229,6 +230,7 @@ protected:
     void state_3();
     void state_4();
     void state_5();
+    void state_6();
 };
 CPPUNIT_TEST_SUITE_REGISTRATION(v12facttest);
 
@@ -1447,4 +1449,32 @@ void v12facttest::state_5()
     CPPUNIT_ASSERT_THROW(
         m_pFactory->makeStateChangeItem(item2), std::bad_cast
     );
+}
+// Making a state change item from a raw ring item should preserve the divisor.
+void v12facttest::state_6() {
+    auto now = time(nullptr);
+    v12::CRingStateChangeItem original(
+        0x1234567890, 2, 0, v12::PAUSE_RUN, 2, 5, now, "Some Title", 2
+    );
+    std::unique_ptr<::CRingStateChangeItem> item;
+    CPPUNIT_ASSERT_NO_THROW(
+        item.reset(m_pFactory->makeStateChangeItem(original))
+    );
+    EQ(uint32_t(2), item->getTimeDivisor());
+    EQ(float(2.5), item->computeElapsedTime());
+
+    // Shoulid be able to do the same thing with a non timestamped item:
+
+    v12::CRingStateChangeItem nots(
+        BEGIN_RUN,
+        124, 5, now, "This is a title", 2
+    );
+    std::unique_ptr<::CRingStateChangeItem> notsitem;
+    CPPUNIT_ASSERT_NO_THROW(
+      
+        notsitem.reset(m_pFactory->makeStateChangeItem(nots))
+    );
+
+    EQ(uint32_t(2), notsitem->getTimeDivisor());
+    EQ(float(2.5), notsitem->computeElapsedTime());
 }


### PR DESCRIPTION
Fixes factory methods for CRingStateChange items when the source ring item has divisors that are not 1.