### PR TITLE
getRingItem from ringbuffer with timeout arg and nullptr return if ti…

### DIFF
--- a/abstract/RingItemFactoryBase.h
+++ b/abstract/RingItemFactoryBase.h
@@ -24,6 +24,7 @@
 #include <cstdint>
 #include <iostream>
 #include <vector>
+#include <climits>
 #include <fmtconfig.h>
 class CRingBuffer;
 namespace ufmt {
@@ -60,7 +61,7 @@ namespace ufmt {
         virtual CRingItem* makeRingItem(const RingItem* pRawRing) = 0;
         
     #ifdef HAVE_NSCLDAQ
-        virtual CRingItem* getRingItem(CRingBuffer& ringbuf) = 0;
+        virtual CRingItem* getRingItem(CRingBuffer& ringbuf, unsigned long timeout=ULONG_MAX) = 0;
     #endif
         virtual CRingItem* getRingItem(int fd) = 0;
         virtual CRingItem* getRingItem(::std::istream& in) = 0;

--- a/v10/RingItemFactory.cpp
+++ b/v10/RingItemFactory.cpp
@@ -122,13 +122,14 @@ namespace ufmt {
      */
     #ifdef HAVE_NSCLDAQ  
     ::ufmt::CRingItem*
-    RingItemFactory::getRingItem(::CRingBuffer& ringbuf)
+    RingItemFactory::getRingItem(::CRingBuffer& ringbuf, unsigned long timeout)
     {
         // Read the header, use it to create a v10 ring item
         // then read the body into it:
         v10::RingItemHeader hdr;
-        ringbuf.get(&hdr, sizeof(hdr));
-        
+        if (!ringbuf.get(&hdr, sizeof(hdr), sizeof(hdr), timeout)) {
+	    return nullptr;
+	}	
         auto result = makeRingItem(hdr.s_type, hdr.s_size);
         uint8_t* p  = reinterpret_cast<uint8_t*>(result->getBodyCursor());
         size_t bodySize = hdr.s_size - sizeof(v10::RingItemHeader);

--- a/v10/RingItemFactory.h
+++ b/v10/RingItemFactory.h
@@ -42,7 +42,7 @@ namespace ufmt {
             ::ufmt::CRingItem* makeRingItem(const ::ufmt::CRingItem& rhs);
             ::ufmt::CRingItem* makeRingItem(const ::ufmt::RingItem* pRawRing);
     #ifdef HAVE_NSCLDAQ  
-            virtual ::ufmt::CRingItem* getRingItem(::CRingBuffer& ringbuf) ;
+            virtual ::ufmt::CRingItem* getRingItem(::CRingBuffer& ringbuf, unsigned long timeout=ULONG_MAX) ;
     #endif
             virtual ::ufmt::CRingItem* getRingItem(int fd) ;
             virtual ::ufmt::CRingItem* getRingItem(::std::istream& in);

--- a/v11/RingItemFactory.cpp
+++ b/v11/RingItemFactory.cpp
@@ -129,10 +129,12 @@ namespace ufmt {
      *  @note we will block as long as needed.
      */
     ::ufmt::CRingItem*
-    RingItemFactory::getRingItem(::CRingBuffer& ringbuf)
+    RingItemFactory::getRingItem(::CRingBuffer& ringbuf, unsigned long timeout)
     {
         v11::RingItemHeader hdr;
-        ringbuf.get(&hdr, sizeof(hdr));
+        if (!ringbuf.get(&hdr, sizeof(hdr), sizeof(hdr), timeout)) {
+	    return nullptr;
+	}
         v11::CRingItem* pItem = new v11::CRingItem(hdr.s_type, hdr.s_size);
         size_t remaining = hdr.s_size - sizeof(v11::RingItemHeader);
         v11::pRingItem pItemStorage =

--- a/v11/RingItemFactory.h
+++ b/v11/RingItemFactory.h
@@ -40,7 +40,7 @@ namespace ufmt {
         virtual ::ufmt::CRingItem* makeRingItem(const ::ufmt::RingItem* pRawRing) ;
 
     #ifdef HAVE_NSCLDAQ    
-        virtual ::ufmt::CRingItem* getRingItem(::CRingBuffer& ringbuf) ;
+        virtual ::ufmt::CRingItem* getRingItem(::CRingBuffer& ringbuf, unsigned long timeout=ULONG_MAX) ;
     #endif    
         virtual ::ufmt::CRingItem* getRingItem(int fd) ;
         virtual ::ufmt::CRingItem* getRingItem(std::istream& in) ;

--- a/v12/RingItemFactory.cpp
+++ b/v12/RingItemFactory.cpp
@@ -120,10 +120,12 @@ namespace ufmt {
      *  @return ::ufmt::CRingItem* - pointer to the dynamically created gotten item.
      */
     ::ufmt::CRingItem*
-    RingItemFactory::getRingItem(::CRingBuffer& ringbuf)
+    RingItemFactory::getRingItem(::CRingBuffer& ringbuf, unsigned long timeout)
     {
         v12::RingItemHeader hdr;
-        ringbuf.get(&hdr, sizeof(hdr), sizeof(hdr));
+        if (!ringbuf.get(&hdr, sizeof(hdr), sizeof(hdr), timeout)) {
+	    return nullptr;
+	}
         v12::CRingItem* pResult = new CRingItem(hdr.s_type, hdr.s_size);
         
         // Read the remainder of the item:

--- a/v12/RingItemFactory.h
+++ b/v12/RingItemFactory.h
@@ -35,7 +35,7 @@ namespace ufmt {
         virtual ::ufmt::CRingItem* makeRingItem(const ::ufmt::RingItem* pRawRing) ;
 
     #ifdef HAVE_NSCLDAQ    
-        virtual ::ufmt::CRingItem* getRingItem(CRingBuffer& ringbuf) ;
+        virtual ::ufmt::CRingItem* getRingItem(CRingBuffer& ringbuf, unsigned long timeout=ULONG_MAX) ;
     #endif
         virtual ::ufmt::CRingItem* getRingItem(int fd) ;
         virtual ::ufmt::CRingItem* getRingItem(::std::istream& in) ;


### PR DESCRIPTION
…med out

fix for #23. if timed out getItem returns nullptr similar to end of source behavior when e.g., reading from a file source.