### PR TITLE
Issue #29 - Undifferentiated ring items should give type.

### DIFF
--- a/v11/CRingItem.cpp
+++ b/v11/CRingItem.cpp
@@ -333,6 +333,11 @@ namespace ufmt {
     size_t              n     = getBodySize(); 
     int                 nPerLine(8);
 
+    auto  pItem = reinterpret_cast<const ufmt::v11::RingItem*>(getItemPointer());
+    
+    dump << "Size: " << pItem->s_header.s_size;
+    dump << " Type: " << typeName() << std::endl;
+
     dump << bodyHeaderToString();
     
     dump << std::hex << std::setfill('0');

--- a/v12/CRingItem.cpp
+++ b/v12/CRingItem.cpp
@@ -313,9 +313,15 @@ namespace ufmt {
   CRingItem::headerToString() const
   {
     std::stringstream  dump;
+
+    auto  pItem = reinterpret_cast<const ufmt::v12::RingItem*>(getItemPointer());
+    dump << "Size: " << pItem->s_header.s_size;
+    dump << " Type: " << typeName() << std::endl;
+
     const uint8_t*      p     = reinterpret_cast<const uint8_t*>(getBodyPointer());
     size_t              n     = getBodySize(); 
     int                 nPerLine(8);
+
 
     dump << bodyHeaderToString();
 


### PR DESCRIPTION
This was an oversight in V11 and v12. fixed.

Resolves issue #29 