### PR TITLE
Add option to skip building unit tests and documentation. Default is off

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,10 @@ set(NSCLDAQ_ROOT "_"  CACHE STRING "_")
 set(NSCLDAQ_INC ${NSCLDAQ_ROOT}/include CACHE STRING "${NSCLDAQ_ROOT}/include")
 set(NSCLDAQ_LIB ${NSCLDAQ_ROOT}/lib CACHE STRING "${NSCLDAQ_ROOT}/lib")
 
+#option to build unit test and documentation, always ON by default
+option(BUILD_TESTS "Build unit tests" ON)
+option(BUILD_DOCS "Build project documentation" ON)
+
 # Make the fmtconfig.h header:
 
 file(WRITE ${CMAKE_BINARY_DIR}/fmtconfig.h "#ifndef FMTCONFIG_H\n")
@@ -16,7 +20,9 @@ endif()
 file(APPEND ${CMAKE_BINARY_DIR}/fmtconfig.h "#endif\n")
 
 install(FILES ${CMAKE_BINARY_DIR}/fmtconfig.h DESTINATION ${CMAKE_INSTALL_PREFIX}/include)
-enable_testing()
+if(BUILD_TESTS)
+	enable_testing()
+endif()
 
 
 
@@ -31,7 +37,9 @@ add_subdirectory(v10)
 add_subdirectory(v11)
 add_subdirectory(v12)
 add_subdirectory(examples)
-add_subdirectory(docs)
+if(BUILD_DOCS)
+	add_subdirectory(docs)
+endif()
 
 #  Now the top level library target:
 
@@ -68,22 +76,24 @@ target_include_directories(
 
 ## Unit tests
 
-add_executable(selectortests
-TestRunner.cpp
-selectortests.cpp
-)
-target_include_directories(selectortests PRIVATE
-${CMAKE_CURRENT_SOURCE_DIR}/abstract
-${CMAKE_CURRENT_SOURCE_DIR}
- ${CMAKE_BINARY_DIR}
-)
+if(BUILD_TESTS)
+	add_executable(selectortests
+		TestRunner.cpp
+		selectortests.cpp
+	)
+	target_include_directories(selectortests PRIVATE
+		${CMAKE_CURRENT_SOURCE_DIR}/abstract
+		${CMAKE_CURRENT_SOURCE_DIR}
+		 ${CMAKE_BINARY_DIR}
+	)
 
-target_compile_options(selectortests PRIVATE -g -O2)
-target_link_options(selectortests PRIVATE -g)
+	target_compile_options(selectortests PRIVATE -g -O2)
+	target_link_options(selectortests PRIVATE -g)
 
-target_link_libraries(selectortests
-  NSCLDAQFormat V10Format V11Format V12Format
-  AbstractFormat
-    cppunit
-)
-add_test(NAME selector COMMAND selectortests)
+	target_link_libraries(selectortests
+		NSCLDAQFormat V10Format V11Format V12Format
+		AbstractFormat
+		cppunit
+	)
+	add_test(NAME selector COMMAND selectortests)
+endif()

--- a/abstract/CMakeLists.txt
+++ b/abstract/CMakeLists.txt
@@ -36,23 +36,25 @@ PUBLIC_HEADER DESTINATION "${CMAKE_INSTALL_PREFIX}/include"
 )
 
 #  Unit tests:
-
-add_executable(
-    unittests
-    TestRunner.cpp ringitemabtests.cpp abendabtests.cpp dformatabtests.cpp
-    glomabtests.cpp physabtests.cpp fragabtests.cpp counterabtests.cpp
-    scabtests.cpp textabtest.cpp unkabtests.cpp sabchangetests.cpp
-    CRingItem.h CAbnormalEndItem.h CGlomParameters.h CPhysicsEventItem.h
-    CRingFragmentItem.h CRingPhysicsEventCountItem.h CRingScalerItem.h
-    CRingTextItem.h CUnknownFragment.h  CRingStateChangeItem.h
-    Asserts.h DataFormat.h 
-)
-
-target_include_directories(unittests PRIVATE ${CMAKE_BINARY_DIR})
-
-target_link_libraries(unittests AbstractFormat cppunit)
-target_compile_options(unittests PRIVATE -g -O2)
-target_link_options(unittests PRIVATE -g)
+if(BUILD_TESTS)
+	add_executable(
+		unittests
+		TestRunner.cpp ringitemabtests.cpp abendabtests.cpp dformatabtests.cpp
+		glomabtests.cpp physabtests.cpp fragabtests.cpp counterabtests.cpp
+		scabtests.cpp textabtest.cpp unkabtests.cpp sabchangetests.cpp
+		CRingItem.h CAbnormalEndItem.h CGlomParameters.h CPhysicsEventItem.h
+		CRingFragmentItem.h CRingPhysicsEventCountItem.h CRingScalerItem.h
+		CRingTextItem.h CUnknownFragment.h  CRingStateChangeItem.h
+		Asserts.h DataFormat.h
+	)
 
 
-add_test(NAME abstract COMMAND unittests)
+	target_include_directories(unittests PRIVATE ${CMAKE_BINARY_DIR})
+
+	target_link_libraries(unittests AbstractFormat cppunit)
+	target_compile_options(unittests PRIVATE -g -O2)
+	target_link_options(unittests PRIVATE -g)
+
+
+	add_test(NAME abstract COMMAND unittests)
+endif()

--- a/v10/CMakeLists.txt
+++ b/v10/CMakeLists.txt
@@ -43,21 +43,23 @@ install(FILES DataFormat.h CRingItem.h CPhysicsEventItem.h
   CRingStateChangeItem.h CRingTextItem.h RingItemFactory.h
   DESTINATION ${CMAKE_INSTALL_PREFIX}/include/v10 )
 
-add_executable(v10unittests
-  TestRunner.cpp v10rbuftests.cpp v10phystests.cpp v10fragtests.cpp
-  v10counttests.cpp v10scalertests.cpp v10statetests.cpp v10txttests.cpp
-  v10factorytests.cpp 
-)
-target_link_libraries(v10unittests 
-  NSCLDAQFormat V10Format V11Format V12Format  AbstractFormat 
-  cppunit 
-)
-target_include_directories(v10unittests PRIVATE
-${CMAKE_CURRENT_SOURCE_DIR}/../abstract
-${CMAKE_CURRENT_SOURCE_DIR}/..
-${NSCLDAQ_INC} ${CMAKE_BINARY_DIR}
-)
-target_compile_options(v10unittests PRIVATE -g -O2 -DNSCLDAQ_ROOT='${NSCLDAQ_ROOT}')
-target_link_options(v10unittests PRIVATE -g)
+if(BUILD_TESTS)
+	add_executable(v10unittests
+		TestRunner.cpp v10rbuftests.cpp v10phystests.cpp v10fragtests.cpp
+		v10counttests.cpp v10scalertests.cpp v10statetests.cpp v10txttests.cpp
+		v10factorytests.cpp
+	)
+	target_link_libraries(v10unittests
+		NSCLDAQFormat V10Format V11Format V12Format  AbstractFormat
+		cppunit
+	)
+	target_include_directories(v10unittests PRIVATE
+		${CMAKE_CURRENT_SOURCE_DIR}/../abstract
+		${CMAKE_CURRENT_SOURCE_DIR}/..
+		${NSCLDAQ_INC} ${CMAKE_BINARY_DIR}
+	)
+	target_compile_options(v10unittests PRIVATE -g -O2 -DNSCLDAQ_ROOT='${NSCLDAQ_ROOT}')
+	target_link_options(v10unittests PRIVATE -g)
 
-add_test(NAME v10Format COMMAND v10unittests)
+	add_test(NAME v10Format COMMAND v10unittests)
+endif()

--- a/v11/CMakeLists.txt
+++ b/v11/CMakeLists.txt
@@ -52,34 +52,36 @@ install(FILES
     DESTINATION ${CMAKE_INSTALL_PREFIX}/include/v11
 )
 
-add_executable(v11unittests
-TestRunner.cpp
-v11ringtests.cpp
-v11abendtests.cpp 
-v11dfmttests.cpp
-v11glomtests.cpp
-v11eventtests.cpp
-v11fragtests.cpp
-v11counttests.cpp
-v11sctests.cpp
-v11statetest.cpp
-v11texttests.cpp
-v11unktests.cpp
-v11factoryTests.cpp
-)
+if(BUILD_TESTS)
+	add_executable(v11unittests
+		TestRunner.cpp
+		v11ringtests.cpp
+		v11abendtests.cpp
+		v11dfmttests.cpp
+		v11glomtests.cpp
+		v11eventtests.cpp
+		v11fragtests.cpp
+		v11counttests.cpp
+		v11sctests.cpp
+		v11statetest.cpp
+		v11texttests.cpp
+		v11unktests.cpp
+		v11factoryTests.cpp
+	)
 
-target_link_libraries(
-  v11unittests 
-  V11Format  AbstractFormat NSCLDAQFormat  V10Format V12Format 
-  cppunit
-)
-target_include_directories(v11unittests PRIVATE
-${CMAKE_CURRENT_SOURCE_DIR}/../abstract
-${CMAKE_CURRENT_SOURCE_DIR}/..
-${NSCLDAQ_INC}
-${CMAKE_BINARY_DIR}
-)
+	target_link_libraries(
+		v11unittests
+		V11Format  AbstractFormat NSCLDAQFormat  V10Format V12Format
+		cppunit
+	)
+	target_include_directories(v11unittests PRIVATE
+		${CMAKE_CURRENT_SOURCE_DIR}/../abstract
+		${CMAKE_CURRENT_SOURCE_DIR}/..
+		${NSCLDAQ_INC}
+		${CMAKE_BINARY_DIR}
+	)
 
-target_compile_options(v11unittests PRIVATE -g -DNSCLDAQ_ROOT='${NSCLDAQ_ROOT}')
-target_link_options(v11unittests PRIVATE -g)
-add_test(NAME v11unittests COMMAND v11unittests)
+	target_compile_options(v11unittests PRIVATE -g -DNSCLDAQ_ROOT='${NSCLDAQ_ROOT}')
+	target_link_options(v11unittests PRIVATE -g)
+	add_test(NAME v11unittests COMMAND v11unittests)
+endif()

--- a/v12/CMakeLists.txt
+++ b/v12/CMakeLists.txt
@@ -63,31 +63,33 @@ install(FILES
     DESTINATION ${CMAKE_INSTALL_PREFIX}/include/v12
 )
 
-add_executable(v12unittests
-  TestRunner.cpp
-  v12ringtest.cpp
-  v12abend.cpp
-  v12fmttests.cpp
-  v12glomtests.cpp
-  v12phystests.cpp
-  v12counttests.cpp
-  v12scltests.cpp
-  v12statetests.cpp
-  v12texttests.cpp
-  v12fragtests.cpp
-  v12factorytests.cpp
-)
+if(BUILD_TESTS)
+	add_executable(v12unittests
+		TestRunner.cpp
+		v12ringtest.cpp
+		v12abend.cpp
+		v12fmttests.cpp
+		v12glomtests.cpp
+		v12phystests.cpp
+		v12counttests.cpp
+		v12scltests.cpp
+		v12statetests.cpp
+		v12texttests.cpp
+		v12fragtests.cpp
+		v12factorytests.cpp
+	)
 
-target_link_libraries(v12unittests
-    NSCLDAQFormat V10Format V11Format V12Format  AbstractFormat 
-    cppunit 
-)
-target_include_directories(v12unittests PRIVATE
-${CMAKE_CURRENT_SOURCE_DIR}/../abstract
-${CMAKE_CURRENT_SOURCE_DIR}/..
-${NSCLDAQ_INC} ${CMAKE_BINARY_DIR}
-)
+	target_link_libraries(v12unittests
+		NSCLDAQFormat V10Format V11Format V12Format  AbstractFormat
+		cppunit
+	)
+	target_include_directories(v12unittests PRIVATE
+		${CMAKE_CURRENT_SOURCE_DIR}/../abstract
+		${CMAKE_CURRENT_SOURCE_DIR}/..
+		${NSCLDAQ_INC} ${CMAKE_BINARY_DIR}
+	)
 
-target_compile_options(v12unittests PRIVATE -g -O2  -DNSCLDAQ_ROOT='${NSCLDAQ_ROOT}')
-target_link_options(v12unittests PRIVATE -g)
-add_test(NAME v12unittests COMMAND v12unittests)
+	target_compile_options(v12unittests PRIVATE -g -O2  -DNSCLDAQ_ROOT='${NSCLDAQ_ROOT}')
+	target_link_options(v12unittests PRIVATE -g)
+	add_test(NAME v12unittests COMMAND v12unittests)
+endif()


### PR DESCRIPTION
Following discussion on issue #26  I am submitting this pull request to add optional compilation of the unit tests and the documentation. The default for the option is OFF.